### PR TITLE
If the endpoint URL already had URL parameters, use an ampersand instead.

### DIFF
--- a/oembed/__init__.py
+++ b/oembed/__init__.py
@@ -303,7 +303,10 @@ class OEmbedEndpoint(object):
             urlApi = self._urlApi.replace('{format}', params['format'])
             del params['format']
                 
-        return "%s?%s" % (urlApi, urllib.urlencode(params)) 
+        if '?' in urlApi:
+            return "%s&%s" % (urlApi, urllib.urlencode(params))
+        else:
+            return "%s?%s" % (urlApi, urllib.urlencode(params))
 
     def get(self, url, **opt):
         '''


### PR DESCRIPTION
This is needed for authenticated embed.ly requests, for example.
