### PR TITLE
support non-standard text/javascript response

### DIFF
--- a/oembed/__init__.py
+++ b/oembed/__init__.py
@@ -360,6 +360,7 @@ class OEmbedEndpoint(object):
            headers['Content-Type'].find('text/xml') != -1:
             response = OEmbedResponse.newFromXML(raw)
         elif headers['Content-Type'].find('application/json') != -1 or \
+             headers['Content-Type'].find('text/javascript') != -1 or \
              headers['Content-Type'].find('text/json') != -1:
             response = OEmbedResponse.newFromJSON(raw)
         else:


### PR DESCRIPTION
Unfortunately, the oembed endpoint of facebook responds with a ``content-type`` of ``text/javascript`` when asked for JSON (see response headers on [this URL](https://www.facebook.com/plugins/video/oembed.json/?url=https%3A%2F%2Fwww.facebook.com%2Ffrostriver%2Fvideos%2F1172907646058518%2F) for an example). This change adds ``text/javascript`` as an accepted ``content-type`` for json.